### PR TITLE
Add --no-time/-t flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	ExcludeFields []string
 	// Filter is a map of fields and values which are used to filter the log output
 	Filter map[string]string
+	// NoTime disables the time output
+	NoTime bool
 }
 
 type rawConfig struct {
@@ -34,6 +36,7 @@ type rawConfig struct {
 	Filter        string `long:"filter" short:"f" description:"Filter fields (key=value comma separated)"`
 	NoColor       bool   `long:"no-color" short:"n" description:"Disable color output"`
 	ForceColor    bool   `long:"force-color" short:"c" description:"Force color output, even when outputting to a pipe"`
+	NoTime        bool   `long:"no-time" short:"t" description:"Disable time output"`
 }
 
 func Parse() (*Config, error) {
@@ -65,6 +68,9 @@ func Parse() (*Config, error) {
 	}
 	if raw.NoColor {
 		color.NoColor = true
+	}
+	if raw.NoTime {
+		cfg.NoTime = true
 	}
 
 	return &cfg, nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -37,7 +37,7 @@ func (p *Parser) Start() error {
 			continue
 		}
 
-		_, err = fmt.Fprintf(p.output, "%s\n", record.String(p.cfg.OutputFields, p.cfg.ExcludeFields))
+		_, err = fmt.Fprintf(p.output, "%s\n", record.String(p.cfg))
 		if err != nil {
 			return fmt.Errorf("failed to print log to output: %w", err)
 		}

--- a/parser/record.go
+++ b/parser/record.go
@@ -140,23 +140,34 @@ func (r *Record) MatchesFilter(filter map[string]string) bool {
 }
 
 // String returns a formatted string representation of the Record
-func (r *Record) String(outputFields []string, excludeFields []string) string {
+func (r *Record) String(cfg *config.Config) string {
 	line := ""
 	for _, key := range r.fieldOrder {
-		if len(outputFields) > 0 && !slices.Contains(outputFields, key) {
+		if len(cfg.OutputFields) > 0 && !slices.Contains(cfg.OutputFields, key) {
 			continue
 		}
-		if len(excludeFields) > 0 && slices.Contains(excludeFields, key) {
+		if len(cfg.ExcludeFields) > 0 && slices.Contains(cfg.ExcludeFields, key) {
 			continue
 		}
 		value := r.fields[key]
 		key = color.HiBlueString(key)
 		line += fmt.Sprintf("%s=%s ", key, getFormattedValue(value))
 	}
-	fmtString := "%s %26s %s"
-	if color.NoColor {
-		fmtString = "%s %7s %s"
+
+	var fmtString strings.Builder
+	if !cfg.NoTime {
+		fmtString.WriteString("%s ")
 	}
 
-	return fmt.Sprintf(fmtString, r.time.Format("2006-01-02 15:04:05"), getFormattedLevel(r.level), line)
+	if color.NoColor {
+		fmtString.WriteString("%7s %s")
+	} else {
+		fmtString.WriteString("%26s %s")
+	}
+
+	if cfg.NoTime {
+		return fmt.Sprintf(fmtString.String(), getFormattedLevel(r.level), line)
+	} else {
+		return fmt.Sprintf(fmtString.String(), r.time.Format("2006-01-02 15:04:05"), getFormattedLevel(r.level), line)
+	}
 }


### PR DESCRIPTION
Services started with systemd have proper journaling info attached to them, including timestamp; thus having another timestamp in the logs is usually not necessary.
This PR adds a `--no-time`/`-t` flag to not try to display a prefixing time if there is none in the parsed logs.