### PR TITLE
fix: throw parser errors when they happen

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,11 +1,13 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
-	"github.com/TheEdgeOfRage/logfmt/config"
 	"github.com/go-logfmt/logfmt"
+
+	"github.com/TheEdgeOfRage/logfmt/config"
 )
 
 type Parser struct {
@@ -43,5 +45,8 @@ func (p *Parser) Start() error {
 		}
 	}
 
-	return nil
+	if errors.Is(decoder.Err(), io.EOF) {
+		return nil
+	}
+	return decoder.Err()
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,20 @@
+package parser_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/TheEdgeOfRage/logfmt/config"
+	"github.com/TheEdgeOfRage/logfmt/parser"
+)
+
+func TestParseInvalidFile(t *testing.T) {
+	f, err := os.Open("../testdata/log.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := parser.NewParser(&config.Config{}, f, os.Stdout)
+	if err := p.Start(); err == nil {
+		t.Error("expected error, got nil")
+	}
+}

--- a/testdata/log.txt
+++ b/testdata/log.txt
@@ -1,0 +1,7 @@
+time="2025-03-15T10:32:23.099371324+01:00" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.btrfs type=io.containerd.snapshotter.v1
+time="2025-03-15T10:32:23.100260643+01:00" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.devmapper type=io.containerd.snapshotter.v1
+time="2025-03-15T10:32:23.100277101+01:00" level=info msg="skip loading plugin" error="devmapper not configured: skip plugin" id=io.containerd.snapshotter.v1.devmapper type=io.containerd.snapshotter.v1
+time="2025-03-15T10:32:23.100288611+01:00" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.native type=io.containerd.snapshotter.v1
+time="2025-03-15T10:32:23.100391684+01:00" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.overlayfs type=io.containerd.snapshotter.v1
+time="2025-03-15T10:32:23.100625849+01:00" level=info msg="loading plugin" id=io.containerd.snapshotter.v1.zfs type=io.containerd.snapshotter.v1
+time="


### PR DESCRIPTION
In certain cases, `logfmt` fails to parse the log line and it silently fails.

In my case, this happens in `containerd` log lines that span multiple file lines such as:

```
time="2025-03-15T10:32:23.100277101+01:00" level=info msg="skip loading plugin" error="devmapper not configured: skip plugin" id=io.containerd.snapshotter.
v1.devmapper type=io.containerd.snapshotter.v1
```

While this is not a fix for this problem per se, at least it will help surface them as they happen.