### PR TITLE
Specify latest version in instal instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ I recommend adding a `GOBIN` env var to your shell with a location to where you 
 and adding that location to your `PATH`. With that set up, you can install logfmt using:
 
 ```
-go install github.com/TheEdgeOfRage/logfmt
+go install github.com/TheEdgeOfRage/logfmt@latest
 ```
 
 ### Usage


### PR DESCRIPTION

When installing from outside a go module directory, trying to install without a
version results in this error message:

    ❯ go install github.com/TheEdgeOfRage/logfmt

    go: 'go install' requires a version when current directory is not in a module
            Try 'go install github.com/TheEdgeOfRage/logfmt@latest' to install the latest version
