### PR TITLE
feat: support --buffer-size

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	Raw bool
 	// All after output in record order (causes output to become order)
 	All bool
+	// How long can a line be?
+	BufferSize int
 }
 
 type rawConfig struct {
@@ -47,6 +49,7 @@ type rawConfig struct {
 	KeepEmpty     bool   `long:"keep-empty" short:"k" description:"Keep lines with no field present selected by output or with all excluded"` // nolint:lll
 	Raw           bool   `long:"raw" short:"r" description:"Output only selected fields values (comma separated) lcut like"`                  // nolint:lll
 	All           bool   `long:"all" short:"A" description:"Output all field after the output fields effectivly making it ordered"`           // nolint:lll
+	BufferSize    int    `long:"buffer-size" short:"B" description:"How long should a line be expected to be?" default:"1048576"`
 }
 
 func Parse() (*Config, error) {
@@ -94,6 +97,9 @@ func Parse() (*Config, error) {
 	}
 	if raw.All {
 		cfg.All = true
+	}
+	if raw.BufferSize != 0 {
+		cfg.BufferSize = raw.BufferSize
 	}
 	return &cfg, nil
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -26,7 +26,7 @@ func NewParser(cfg *config.Config, input io.Reader, output io.Writer) *Parser {
 
 // Start starts the parser, reading from the input stream and printing the log output to the output stream line by line
 func (p *Parser) Start() error {
-	decoder := logfmt.NewDecoder(p.input)
+	decoder := logfmt.NewDecoderSize(p.input, p.cfg.BufferSize)
 	for decoder.ScanRecord() {
 		record, err := NewRecord(decoder, p.cfg)
 		if err != nil {


### PR DESCRIPTION
When a very long line is encountered, the buffer size can be increased in exchange for using more memory.

Example from the issue:

```shell
$ python3 -c 'print("level=info " + "hello=world "*5000000)' | logfmt
bufio.Scanner: token too long

$ python3 -c 'print("level=info " + "hello=world "*50000)' | logfmt -B "$(fend '64*1024*1024')" | head -c50
0001-01-01 00:00:00  [INFO] hello=world hello=worl
```

Fixes: https://github.com/TheEdgeOfRage/logfmt/issues/15